### PR TITLE
MB-70044: Add MutateWithMeta command

### DIFF
--- a/daemon/datatype_filter.cc
+++ b/daemon/datatype_filter.cc
@@ -57,6 +57,7 @@ void DatatypeFilter::enable(cb::mcbp::Feature feature) {
     case cb::mcbp::Feature::GetRandomKeyIncludeXattr:
     case cb::mcbp::Feature::RangeScanIncludeXattr:
     case cb::mcbp::Feature::SubdocAllowReplicaReadOnDeletedDocs:
+    case cb::mcbp::Feature::MutateWithMeta:
         throw std::invalid_argument("Datatype::enable invalid feature:" +
                                     std::to_string(int(feature)));
     }

--- a/daemon/mcbp_executors.cc
+++ b/daemon/mcbp_executors.cc
@@ -43,6 +43,7 @@
 #include "protocol/mcbp/ifconfig_context.h"
 #include "protocol/mcbp/ioctl_command_context.h"
 #include "protocol/mcbp/mount_fusion_vbucket_command_context.h"
+#include "protocol/mcbp/mutate_with_meta_context.h"
 #include "protocol/mcbp/mutation_context.h"
 #include "protocol/mcbp/no_success_response_steppable_context.h"
 #include "protocol/mcbp/observe_context.h"
@@ -194,6 +195,10 @@ static void set_executor(Cookie& cookie) {
 
 static void replace_executor(Cookie& cookie) {
     add_set_replace_executor(cookie, StoreSemantics::Replace);
+}
+
+static void mutate_with_meta_executor(Cookie& cookie) {
+    cookie.obtainContext<MutateWithMetaCommandContext>(cookie).drive();
 }
 
 static void append_prepend_executor(Cookie& cookie) {
@@ -864,6 +869,8 @@ void initialize_mbcp_lookup_map() {
         handler = process_bin_unknown_packet;
     }
 
+    setup_handler(cb::mcbp::ClientOpcode::MutateWithMeta,
+                  mutate_with_meta_executor);
     setup_handler(cb::mcbp::ClientOpcode::DcpOpen, dcp_open_executor);
     setup_handler(cb::mcbp::ClientOpcode::DcpAddStream,
                   dcp_add_stream_executor);

--- a/daemon/mcbp_privileges.cc
+++ b/daemon/mcbp_privileges.cc
@@ -238,6 +238,7 @@ McbpPrivilegeChains::McbpPrivilegeChains() {
     setup(ClientOpcode::AddqWithMeta, requireMetaWriteOnCurrentDocument);
     setup(ClientOpcode::DelWithMeta, requireMetaWriteOnCurrentDocument);
     setup(ClientOpcode::DelqWithMeta, requireMetaWriteOnCurrentDocument);
+    setup(ClientOpcode::MutateWithMeta, requireMetaWriteOnCurrentDocument);
     setup(ClientOpcode::EnableTraffic, require<Privilege::NodeSupervisor>);
     setup(ClientOpcode::DisableTraffic, require<Privilege::NodeSupervisor>);
     setup(ClientOpcode::Ifconfig, require<Privilege::NodeSupervisor>);

--- a/daemon/mcbp_validators.cc
+++ b/daemon/mcbp_validators.cc
@@ -2086,6 +2086,17 @@ static Status mutate_with_meta_validator(Cookie& cookie) {
     return Status::Success;
 }
 
+static Status mutate_with_meta_ex_validator(Cookie& cookie) {
+    // The command performs deeper validation of the extras
+    return McbpValidator::verify_header(cookie,
+                                        cookie.getHeader().getExtlen(),
+                                        ExpectedKeyLen::NonZero,
+                                        ExpectedValueLen::Any,
+                                        ExpectedCas::Any,
+                                        GeneratesDocKey::Yes,
+                                        McbpValidator::AllSupportedDatatypes);
+}
+
 static Status get_errmap_validator(Cookie& cookie) {
     auto status = McbpValidator::verify_header(cookie,
                                                0,
@@ -3521,6 +3532,7 @@ McbpValidator::McbpValidator() {
     setup(ClientOpcode::SetWithMeta, mutate_with_meta_validator);
     setup(ClientOpcode::AddWithMeta, mutate_with_meta_validator);
     setup(ClientOpcode::DelWithMeta, mutate_with_meta_validator);
+    setup(ClientOpcode::MutateWithMeta, mutate_with_meta_ex_validator);
     setup(ClientOpcode::GetErrorMap, get_errmap_validator);
     setup(ClientOpcode::GetLocked, get_locked_validator);
     setup(ClientOpcode::UnlockKey, unlock_validator);

--- a/daemon/protocol/mcbp/CMakeLists.txt
+++ b/daemon/protocol/mcbp/CMakeLists.txt
@@ -77,6 +77,8 @@ add_library(memcached_daemon_mcbp OBJECT
         list_bucket_executor.cc
         mount_fusion_vbucket_command_context.cc
         mount_fusion_vbucket_command_context.h
+        mutate_with_meta_context.cc
+        mutate_with_meta_context.h
         mutation_context.cc
         mutation_context.h
         no_success_response_steppable_context.h

--- a/daemon/protocol/mcbp/hello_packet_executor.cc
+++ b/daemon/protocol/mcbp/hello_packet_executor.cc
@@ -84,6 +84,7 @@ void buildRequestVector(FeatureSet& requested,
         case Feature::RangeScanIncludeXattr:
         case Feature::SubdocAllowReplicaReadOnDeletedDocs:
         case Feature::GetRandomKeyIncludeXattr:
+        case Feature::MutateWithMeta:
 
             // This isn't very optimal, but we've only got a handfull of
             // elements ;)
@@ -129,6 +130,7 @@ void buildRequestVector(FeatureSet& requested,
         case Feature::TcpNoDelay:
         case Feature::TCPDELAY_Unsupported:
         case Feature::SubdocAllowReplicaReadOnDeletedDocs:
+        case Feature::MutateWithMeta:
             // No other dependency
             break;
 
@@ -383,6 +385,7 @@ void process_hello_packet_executor(Cookie& cookie) {
         case Feature::RangeScanIncludeXattr:
         case Feature::SubdocAllowReplicaReadOnDeletedDocs:
         case Feature::GetRandomKeyIncludeXattr:
+        case Feature::MutateWithMeta:
             // Informative features don't need special handling
             added = true;
             break;

--- a/daemon/protocol/mcbp/mutate_with_meta_context.cc
+++ b/daemon/protocol/mcbp/mutate_with_meta_context.cc
@@ -1,0 +1,376 @@
+/*
+ *     Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Use of this software is governed by the Business Source License included
+ *   in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ *   in that file, in accordance with the Business Source License, use of this
+ *   software will be governed by the Apache License, Version 2.0, included in
+ *   the file licenses/APL2.txt.
+ */
+
+#include "mutate_with_meta_context.h"
+#include "engine_wrapper.h"
+#include <daemon/buckets.h>
+#include <daemon/cookie.h>
+#include <daemon/front_end_thread.h>
+#include <daemon/memcached.h>
+#include <logger/logger.h>
+#include <mcbp/codec/with_meta_options.h>
+#include <mcbp/protocol/datatype.h>
+#include <memcached/durability_spec.h>
+#include <memcached/protocol_binary.h>
+#include <memcached/types.h>
+#include <nlohmann/json.hpp>
+#include <platform/string_hex.h>
+#include <utilities/json_utilities.h>
+#include <xattr/blob.h>
+#include <xattr/utils.h>
+
+#include <charconv>
+
+using cb::mcbp::request::MutateWithMetaCommand;
+
+MutateWithMetaCommandContext::MutateWithMetaCommandContext(Cookie& cookie)
+    : SteppableCommandContext(cookie) {
+}
+
+cb::engine_errc MutateWithMetaCommandContext::pre_link_document(
+        item_info& info) {
+    if ((cas_offsets.empty() && seqno_offsets.empty()) ||
+        !cb::mcbp::datatype::is_xattr(info.datatype)) {
+        // we have no offsets to insert or there are no xattrs
+        LOG_DEBUG_CTX(
+                "Pre link document called - no xattrs present or no "
+                "offsets specified",
+                {"conn_id", cookie.getConnectionId()});
+        return cb::engine_errc::success;
+    }
+
+    const auto datatype = static_cast<cb::mcbp::Datatype>(info.datatype);
+    LOG_DEBUG_CTX("Pre link document called",
+                  {"cas", cb::to_hex(htonll(info.cas))},
+                  {"seqno", cb::to_hex(info.seqno)},
+                  {"datatype", to_json(datatype)});
+
+    Expects(!cb::mcbp::datatype::is_snappy(info.datatype));
+    cb::char_buffer blob_buffer{static_cast<char*>(info.value[0].iov_base),
+                                info.value[0].iov_len};
+    auto offset = cb::xattr::get_body_offset(
+            {blob_buffer.data(), blob_buffer.size()});
+    auto view = cb::char_buffer{blob_buffer.data(), offset};
+
+    // Write CAS value at all specified offsets
+    const auto cas_hex = cb::to_hex(htonll(info.cas));
+    for (auto cas_offset : cas_offsets) {
+        if (cas_offset + cas_hex.size() <= view.size()) {
+            // This should be done as part of the validation step
+            Expects(cas_offset + cas_hex.size() <= view.size());
+            std::copy_n(
+                    cas_hex.data(), cas_hex.size(), view.data() + cas_offset);
+        }
+    }
+
+    // Write seqno value at all specified offsets
+    const auto seqno_hex = cb::to_hex(info.seqno);
+    for (auto seqno_offset : seqno_offsets) {
+        if (seqno_offset + seqno_hex.size() <= view.size()) {
+            // This should be done as part of the validation step
+            Expects(seqno_offset + seqno_hex.size() <= view.size());
+            std::copy_n(seqno_hex.data(),
+                        seqno_hex.size(),
+                        view.data() + seqno_offset);
+        }
+    }
+
+    return cb::engine_errc::success;
+}
+
+cb::engine_errc MutateWithMetaCommandContext::step() {
+    const auto start = std::chrono::steady_clock::now();
+    auto guard = folly::makeGuard([this, &start] {
+        auto stop = std::chrono::steady_clock::now();
+        cookie.getTracer().record(cb::tracing::Code::SetWithMeta, start, stop);
+    });
+
+    auto ret = cb::engine_errc::success;
+    do {
+        switch (state) {
+        case State::ValidateInput:
+            ret = validateInput();
+            break;
+        case State::StoreItem:
+            ret = storeItem();
+            break;
+        case State::SendResponse:
+            if (cookie.getConnection().isSupportsMutationExtras()) {
+                mutation_descr.vbucket_uuid =
+                        htonll(mutation_descr.vbucket_uuid);
+                mutation_descr.seqno = htonll(mutation_descr.seqno);
+                cookie.sendResponse(
+                        cb::mcbp::Status::Success,
+                        {reinterpret_cast<const char*>(&mutation_descr),
+                         sizeof(mutation_descr)},
+                        {},
+                        {},
+                        cb::mcbp::Datatype::Raw,
+                        cookie.getCas());
+            } else {
+                cookie.sendResponse(cb::mcbp::Status::Success);
+            }
+            return cb::engine_errc::success;
+        }
+    } while (ret == cb::engine_errc::success);
+    return ret;
+}
+
+std::variant<cb::engine_errc, cb::mcbp::request::MutateWithMetaPayload>
+MutateWithMetaCommandContext::parseJson() {
+    const auto& request = cookie.getRequest();
+    cb::mcbp::request::MutateWithMetaPayload payload;
+    try {
+        if (request.getExtlen() != sizeof(uint32_t)) {
+            cookie.setErrorContext("Invalid extras length");
+            return cb::engine_errc::invalid_arguments;
+        }
+
+        const auto meta_len = getMetaSize();
+        const auto value = cookie.getInflatedInputPayload();
+        if (meta_len > value.size()) {
+            cookie.setErrorContext("Invalid metadata length");
+            return cb::engine_errc::invalid_arguments;
+        }
+
+        auto meta = value.substr(value.size() - meta_len);
+        payload = nlohmann::json::parse(meta);
+    } catch (const std::exception& exception) {
+        const std::string_view prefix = "cb::getValueFromJson(): ";
+        std::string message = exception.what();
+        if (message.starts_with(prefix)) {
+            message = message.substr(prefix.size());
+        } else {
+            message = "Failed to parse extended attributes as JSON";
+        }
+        cookie.setErrorContext(std::move(message));
+        return cb::engine_errc::invalid_arguments;
+    }
+
+    return payload;
+}
+
+cb::engine_errc MutateWithMetaCommandContext::validateGenerateCasOptions(
+        const cb::mcbp::request::MutateWithMetaPayload& payload) {
+    if (payload.options.generate_cas == GenerateCas::No) {
+        if (!payload.cas.has_value()) {
+            cookie.setErrorContext(
+                    "CAS must be specified when generate_cas is No");
+            return cb::engine_errc::invalid_arguments;
+        }
+        if (!payload.cas_offsets.empty()) {
+            cookie.setErrorContext(
+                    "cas_offsets cannot be specified when cas is set");
+            return cb::engine_errc::invalid_arguments;
+        }
+        if (!payload.seqno_offsets.empty()) {
+            cookie.setErrorContext(
+                    "seqno_offsets cannot be specified when cas is set");
+            return cb::engine_errc::invalid_arguments;
+        }
+        return cb::engine_errc::success;
+    }
+    if (payload.cas.has_value()) {
+        cookie.setErrorContext(
+                "CAS cannot be specified when generate_cas is set");
+        return cb::engine_errc::invalid_arguments;
+    }
+
+    return cb::engine_errc::success;
+}
+
+cb::engine_errc MutateWithMetaCommandContext::validatePatternRequirements(
+        std::string_view value, protocol_binary_datatype_t datatype) {
+    if (cas_offsets.empty() && seqno_offsets.empty()) {
+        return cb::engine_errc::success;
+    }
+
+    if (value.empty()) {
+        cookie.setErrorContext("Cannot use pattern macros on empty documents");
+        return cb::engine_errc::invalid_arguments;
+    }
+
+    if (!cb::mcbp::datatype::is_xattr(datatype)) {
+        cookie.setErrorContext(
+                "Cannot use pattern macros documents without xattr");
+        return cb::engine_errc::invalid_arguments;
+    }
+
+    auto* xattr_blob = const_cast<char*>(value.data());
+    const auto xattr_size = cb::xattr::get_body_offset(value);
+    // size of the hex representation of 64-bit value with a 0x prefix
+    constexpr size_t pattern_size = 18;
+    auto fill = cb::to_hex(std::numeric_limits<uint64_t>::max());
+    for (auto cas_offset : cas_offsets) {
+        if (cas_offset + pattern_size > xattr_size) {
+            cookie.setErrorContext(
+                    "CAS offset is out of bounds of the xattr section");
+            return cb::engine_errc::invalid_arguments;
+        }
+        std::copy(fill.begin(),
+                  fill.begin() + fill.size(),
+                  xattr_blob + cas_offset);
+    }
+    for (auto seqno_offset : seqno_offsets) {
+        if (seqno_offset + pattern_size > xattr_size) {
+            cookie.setErrorContext(
+                    "Seqno offset is out of bounds of the xattr section");
+            return cb::engine_errc::invalid_arguments;
+        }
+        std::copy(fill.begin(),
+                  fill.begin() + fill.size(),
+                  xattr_blob + seqno_offset);
+    }
+
+    // We've patched the blob.. rerun validation to ensure it's still a valid
+    // blob if we replace with the pattern.
+    if (!cookie.getConnection().getThread().isXattrBlobValid(value)) {
+        cookie.setErrorContext(
+                "Patching seqno and cas would garble the xattr section");
+        return cb::engine_errc::invalid_arguments;
+    }
+
+    return cb::engine_errc::success;
+}
+
+cb::engine_errc MutateWithMetaCommandContext::validateDeleteCommandRequirements(
+        std::string_view value, protocol_binary_datatype_t datatype) {
+    if (cb::mcbp::datatype::is_xattr(datatype)) {
+        if (!value.empty() &&
+            cb::xattr::get_body_offset(value) != value.size()) {
+            cookie.setErrorContext(
+                    "Delete with meta: Document cannot have a body");
+            return cb::engine_errc::invalid_arguments;
+        }
+        cb::char_buffer buffer{const_cast<char*>(value.data()), value.size()};
+        cb::xattr::Blob blob(buffer);
+        if (blob.has_user_keys()) {
+            cookie.setErrorContext(
+                    "Delete with meta: user-xattrs is not allowed");
+            return cb::engine_errc::invalid_arguments;
+        }
+    } else if (!value.empty()) {
+        cookie.setErrorContext("Delete with meta: Document cannot have a body");
+        return cb::engine_errc::invalid_arguments;
+    }
+    return cb::engine_errc::success;
+}
+
+cb::engine_errc MutateWithMetaCommandContext::validateInput() {
+    cb::mcbp::request::MutateWithMetaPayload payload;
+    {
+        auto ret = parseJson();
+        if (std::holds_alternative<cb::engine_errc>(ret)) {
+            return std::get<cb::engine_errc>(ret);
+        }
+        payload = std::get<cb::mcbp::request::MutateWithMetaPayload>(ret);
+    }
+
+    // flags is stored in network byte order internally
+    command = payload.command;
+    item_meta.cas = payload.cas.value_or(1);
+    item_meta.revSeqno = payload.rev_seqno.value_or(DEFAULT_REV_SEQ_NUM);
+    item_meta.flags = htonl(payload.flags);
+    item_meta.exptime = payload.exptime;
+    options = payload.options;
+    cas_offsets = std::move(payload.cas_offsets);
+    seqno_offsets = std::move(payload.seqno_offsets);
+
+    auto ret = validateGenerateCasOptions(payload);
+    if (ret != cb::engine_errc::success) {
+        return ret;
+    }
+
+    const auto datatype = static_cast<protocol_binary_datatype_t>(
+                                  cookie.getRequest().getDatatype()) &
+                          ~PROTOCOL_BINARY_DATATYPE_SNAPPY;
+    const auto value = getDocumentData();
+
+    ret = validatePatternRequirements(value, datatype);
+    if (ret != cb::engine_errc::success) {
+        return ret;
+    }
+
+    if (command == MutateWithMetaCommand::Delete) {
+        ret = validateDeleteCommandRequirements(value, datatype);
+        if (ret != cb::engine_errc::success) {
+            return ret;
+        }
+    }
+
+    state = State::StoreItem;
+    return cb::engine_errc::success;
+}
+
+cb::engine_errc MutateWithMetaCommandContext::storeItem() {
+    const auto& request = cookie.getRequest();
+    mutation_descr.seqno = 0;
+    mutation_descr.vbucket_uuid = std::numeric_limits<uint64_t>::max();
+    cb::engine_errc ret;
+    uint64_t commandCas = request.getCas();
+    const auto datatype = static_cast<protocol_binary_datatype_t>(
+                                  cookie.getRequest().getDatatype()) &
+                          ~PROTOCOL_BINARY_DATATYPE_SNAPPY;
+    const auto value = getDocumentData();
+    if (command == MutateWithMetaCommand::Delete && value.empty()) {
+        ret = bucket_delete_with_meta(cookie,
+                                      request.getVBucket(),
+                                      cookie.getRequestKey(),
+                                      item_meta,
+                                      commandCas,
+                                      mutation_descr,
+                                      options.check_conflicts,
+                                      GenerateBySeqno::Yes,
+                                      options.generate_cas,
+                                      options.delete_source,
+                                      options.force_accept);
+    } else {
+        std::optional<DeleteSource> deleteSource;
+        if (command == MutateWithMetaCommand::Delete) {
+            deleteSource = options.delete_source;
+        }
+        auto buffer = cb::const_byte_buffer(
+                reinterpret_cast<const uint8_t*>(value.data()), value.size());
+        ret = bucket_set_with_meta(cookie,
+                                   request.getVBucket(),
+                                   cookie.getRequestKey(),
+                                   buffer,
+                                   item_meta,
+                                   deleteSource,
+                                   datatype,
+                                   commandCas,
+                                   mutation_descr,
+                                   options.check_conflicts,
+                                   command != MutateWithMetaCommand::Add,
+                                   GenerateBySeqno::Yes,
+                                   options.generate_cas,
+                                   options.force_accept);
+    }
+
+    if (ret == cb::engine_errc::success) {
+        cookie.setCas(commandCas);
+        state = State::SendResponse;
+    }
+
+    return ret;
+}
+
+std::size_t MutateWithMetaCommandContext::getMetaSize() const {
+    const auto& extras = cookie.getHeader().getExtdata();
+    uint32_t meta_len = 0;
+    memcpy(&meta_len, extras.data(), sizeof(meta_len));
+    meta_len = ntohl(meta_len);
+    return meta_len;
+}
+
+std::string_view MutateWithMetaCommandContext::getDocumentData() const {
+    auto view = cookie.getInflatedInputPayload();
+    return view.substr(0, view.size() - getMetaSize());
+}

--- a/daemon/protocol/mcbp/mutate_with_meta_context.h
+++ b/daemon/protocol/mcbp/mutate_with_meta_context.h
@@ -1,0 +1,149 @@
+/*
+ *     Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Use of this software is governed by the Business Source License included
+ *   in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ *   in that file, in accordance with the Business Source License, use of this
+ *   software will be governed by the Apache License, Version 2.0, included in
+ *   the file licenses/APL2.txt.
+ */
+#pragma once
+
+#include "steppable_command_context.h"
+
+#include <mcbp/codec/mutate_with_meta_payload.h>
+#include <mcbp/codec/with_meta_options.h>
+#include <memcached/engine.h>
+#include <variant>
+
+/**
+ * The MutateWithMetaCommandContext is a state machine used by the memcached
+ * core to implement MutateWithMeta command. MutateWithMeta differs from
+ * Add/Set/DeleteWithMeta in two ways:
+ *
+ *  1. The metadata is specified in JSON and not binary encoded where each
+ *     value depends on the offset it is located at (and the size of the
+ *     extras section determines which values to look for)
+ *  2. The command may perform pre-link document processing to replace segments
+ *     in xattrs with new values for CAS and sequence number, which is not
+ *     supported by the Add/Set/DeleteWithMeta commands and the motivation
+ *     for creating the new command.
+ *
+ *.For both CAS and sequence number replacement, the client provides offsets
+ * within the document where the values should be written. The pre-link document
+ * processing will then write the actual CAS and sequence number values at the
+ * specified locations before storing the item.
+ *
+ * The command goes through the following states:
+ * - ValidateInput: Validate the input parameters provided by the user
+ * - StoreItem: Store the item in the underlying engine
+ * - SendResponse: Send the response back to the user
+ *
+ * The command may also perform pre-link document processing to replace
+ * segments in xattrs with new values for CAS and sequence number.
+ *
+ * The extras segment of the command contains a 4 byte integer which
+ * specifies the number of bytes at the end of the value which contains
+ * the metadata for the operation. The metadata is JSON encoded and may
+ * contain options for the operation, as well as optional CAS and sequence
+ * number pattern strings:
+ *
+ *     {
+ *       "cas": "0x0000000000000001",
+ *       "expiration": "0x00000000",
+ *       "flags": "0xdeadbeef",
+ *       "rev_seqno": "0x0000000000000001",
+ *       "command": "add",
+ *       "options": "0x0000000c",
+ *       "cas_offsets": [10, 50, 100],
+ *       "seqno_offsets": [30, 70, 120]
+ *     }
+ *
+ * The "cas", "expiration", "flags", and "rev_seqno" fields specify the metadata
+ * for the item to be stored. The values may be in hexadecimal string format
+ * (with a 0x prefix), or as decimal strings (or JSON numbers, but beware that
+ * 64 bit numbers may overflow the JSON number representation in certain JSON
+ * decoders. Use strings to be safe)).
+ *
+ * The "command" field may be "add", "set", or "delete" and indicates how
+ * the item should be stored.
+ *
+ * The "options" field is a bitmask of:
+ *   - REGENERATE_CAS (0x04)
+ *   - SKIP_CONFLICT_RESOLUTION_FLAG (0x08)
+ *   - FORCE_ACCEPT_WITH_META_OPS (0x20)
+ *   - IS_EXPIRATION (0x10) - only valid for delete operations
+ *   (this is the same value as passed to Add/Set/DeleteWithMeta commands)
+ *
+ * The "cas_offsets" and "seqno_offsets" fields are optional arrays of byte
+ * offsets within the document where the CAS and sequence number values
+ * (as 18-byte hex strings with 0x prefix) should be written.
+ */
+class MutateWithMetaCommandContext : public SteppableCommandContext {
+public:
+    enum class State : uint8_t { ValidateInput, StoreItem, SendResponse };
+
+    MutateWithMetaCommandContext(Cookie& cookie);
+
+    cb::engine_errc pre_link_document(item_info&) override;
+
+protected:
+    cb::engine_errc step() override;
+    cb::engine_errc validateInput();
+    cb::engine_errc storeItem();
+
+private:
+    /// Parse the provided JSON and perform basic validation of their values
+    /// (that they are in the correct format and that the required fields are
+    /// present. Note that this does not perform validation of the actual
+    /// values, such as checking that the values provided match the options
+    /// specified for the command etc). The error context will be set with
+    /// more details if the parsing or validation fails.
+    std::variant<cb::engine_errc, cb::mcbp::request::MutateWithMetaPayload>
+    parseJson();
+
+    /// Validate that a CAS is only present when GenerateCas is set to NO and
+    /// that the CAS pattern and sequence number is only present when
+    /// GenerateCas is set to YES. The error context will be set with more
+    /// details if the validation fails.
+    cb::engine_errc validateGenerateCasOptions(
+            const cb::mcbp::request::MutateWithMetaPayload& payload);
+
+    /// Validate that the if a pattern is provided the document isn't
+    /// compressed and contains an XATTR sectiion
+    cb::engine_errc validatePatternRequirements(
+            std::string_view value, protocol_binary_datatype_t datatype);
+
+    /// Validate that the document don't contain user xattrs and that the
+    /// document body is empty
+    cb::engine_errc validateDeleteCommandRequirements(
+            std::string_view value, protocol_binary_datatype_t datatype);
+
+    /**
+     * Get the size of the metadata segment at the end of the value from the
+     * extras field of the command.
+     */
+    std::size_t getMetaSize() const;
+    /**
+     * Get the document data to store (i.e. the part of the value which is not
+     * the metadata segment at the end of the value). This is the part of the
+     * value which should be stored as the document value, and the metadata
+     * segment at the end of the value should be ignored by the underlying
+     * engine.
+     */
+    std::string_view getDocumentData() const;
+
+    ItemMetaData item_meta;
+    cb::mcbp::WithMetaOptions options;
+    cb::mcbp::request::MutateWithMetaCommand command =
+            cb::mcbp::request::MutateWithMetaCommand::Add;
+    std::vector<std::size_t> cas_offsets;
+    std::vector<std::size_t> seqno_offsets;
+
+    /// The mutation descriptor for the mutation to return back to the client
+    /// upon success
+    mutation_descr_t mutation_descr{};
+
+    /// The current state
+    State state = State::ValidateInput;
+};

--- a/engines/ep/src/vbucket.cc
+++ b/engines/ep/src/vbucket.cc
@@ -2253,6 +2253,8 @@ cb::engine_errc VBucket::setWithMeta(
             {} /*overwritingPrepareSeqno*/,
             cHandle.getCanDeduplicate(),
             enforceMemCheck};
+    PreLinkDocumentContext preLinkDocumentContext(engine, cookie, &itm);
+    queueItmCtx.preLinkDocumentContext = &preLinkDocumentContext;
 
     auto [status, notifyCtx] = processSet(htRes,
                                           v,

--- a/engines/utilities/engine.cc
+++ b/engines/utilities/engine.cc
@@ -99,6 +99,39 @@ cb::EngineErrorItemPair EngineIface::get_random_document(CookieIface& cookie,
     return cb::makeEngineErrorItemPair(cb::engine_errc::not_supported);
 }
 
+cb::engine_errc EngineIface::set_with_meta(
+        CookieIface& cookie,
+        Vbid vbucket,
+        DocKeyView key,
+        cb::const_byte_buffer value,
+        ItemMetaData item_meta,
+        std::optional<DeleteSource> delete_source,
+        protocol_binary_datatype_t datatype,
+        uint64_t& cas,
+        mutation_descr_t& mut_info,
+        CheckConflicts check_conflicts,
+        bool allow_existing,
+        GenerateBySeqno generate_by_seqno,
+        GenerateCas generate_cas,
+        ForceAcceptWithMetaOperation force) {
+    return cb::engine_errc::not_supported;
+}
+
+cb::engine_errc EngineIface::delete_with_meta(
+        CookieIface& cookie,
+        Vbid vbucket,
+        DocKeyView key,
+        ItemMetaData item_meta,
+        uint64_t& cas,
+        mutation_descr_t& mut_info,
+        CheckConflicts check_conflicts,
+        GenerateBySeqno generate_by_seqno,
+        GenerateCas generate_cas,
+        DeleteSource delete_source,
+        ForceAcceptWithMetaOperation force) {
+    return cb::engine_errc::not_supported;
+}
+
 std::string to_string(const TrafficControlMode mode) {
     switch (mode) {
     case TrafficControlMode::Enabled:

--- a/include/mcbp/codec/mutate_with_meta_payload.h
+++ b/include/mcbp/codec/mutate_with_meta_payload.h
@@ -1,0 +1,47 @@
+/*
+ *     Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Use of this software is governed by the Business Source License included
+ *   in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ *   in that file, in accordance with the Business Source License, use of this
+ *   software will be governed by the Apache License, Version 2.0, included in
+ *   the file licenses/APL2.txt.
+ */
+
+#pragma once
+
+#include "with_meta_options.h"
+
+#include <memcached/types.h>
+#include <nlohmann/json_fwd.hpp>
+#include <vector>
+
+namespace cb::mcbp::request {
+
+enum class MutateWithMetaCommand {
+    Add,
+    Set,
+    Delete,
+};
+
+void to_json(nlohmann::json& json, const MutateWithMetaCommand& cmd);
+void from_json(const nlohmann::json& json, MutateWithMetaCommand& cmd);
+
+struct MutateWithMetaPayload {
+    MutateWithMetaCommand command;
+    std::optional<uint64_t> cas;
+    std::optional<uint64_t> rev_seqno;
+    uint32_t flags;
+    uint32_t exptime;
+
+    WithMetaOptions options;
+    std::vector<std::size_t> cas_offsets;
+    std::vector<std::size_t> seqno_offsets;
+
+    bool operator==(const MutateWithMetaPayload&) const = default;
+};
+
+void to_json(nlohmann::json& json, const MutateWithMetaPayload& payload);
+void from_json(const nlohmann::json& json, MutateWithMetaPayload& payload);
+
+} // namespace cb::mcbp::request

--- a/include/mcbp/codec/with_meta_options.h
+++ b/include/mcbp/codec/with_meta_options.h
@@ -22,7 +22,7 @@ struct WithMetaOptions {
     bool operator==(const WithMetaOptions&) const = default;
 
     /// Encode the options back into a bitfield
-    uint32_t encode();
+    uint32_t encode() const;
 
     CheckConflicts check_conflicts = CheckConflicts::Yes;
     GenerateCas generate_cas = GenerateCas::No;

--- a/include/mcbp/protocol/feature.h
+++ b/include/mcbp/protocol/feature.h
@@ -168,6 +168,10 @@ enum class [[nodiscard]] Feature : uint16_t {
     /// server). It may be used from the client to determine if the server
     /// supports returning xattrs along with documents for GetRandomKey
     GetRandomKeyIncludeXattr = 0x24,
+    /// This is purely information (it does not enable / disable anything on the
+    /// server). It may be used from the client to determine if the server
+    /// supports the MutateWithMeta command.
+    MutateWithMeta = 0x25,
 };
 
 [[nodiscard]] std::string format_as(Feature feature);

--- a/include/mcbp/protocol/opcode.h
+++ b/include/mcbp/protocol/opcode.h
@@ -126,6 +126,7 @@ enum class ClientOpcode : uint8_t {
 
     GetEx = 0x49,
     GetExReplica = 0x4a,
+    MutateWithMeta = 0x4b,
 
     /* DCP */
     DcpOpen = 0x50,

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -594,9 +594,7 @@ struct EngineIface {
             bool allow_existing,
             GenerateBySeqno generate_by_seqno,
             GenerateCas generate_cas,
-            ForceAcceptWithMetaOperation force) {
-        return cb::engine_errc::not_supported;
-    }
+            ForceAcceptWithMetaOperation force);
 
     /**
      * Process the del_with_meta with the given buffers/values.
@@ -627,9 +625,7 @@ struct EngineIface {
             GenerateBySeqno generate_by_seqno,
             GenerateCas generate_cas,
             DeleteSource delete_source,
-            ForceAcceptWithMetaOperation force) {
-        return cb::engine_errc::not_supported;
-    }
+            ForceAcceptWithMetaOperation force);
 
     /**
      * Flush the cache.

--- a/include/xattr/blob.h
+++ b/include/xattr/blob.h
@@ -85,6 +85,16 @@ public:
         prune_keys(Type::System);
     }
 
+    /// Check if the blob contains any user keys
+    [[nodiscard]]
+    bool has_user_keys() const {
+        // If the blob is empty the size is reported as 0 bytes.
+        // otherwise a Blob section user (or system) would be at least
+        // 4 bytes (the length field for the Blob). Any *actual* user
+        // keys would make the size larger than 4 bytes.
+        return get_user_size() > 4;
+    }
+
     /**
      * Finalize the buffer and return it's content.
      *

--- a/protocol/connection/client_connection.cc
+++ b/protocol/connection/client_connection.cc
@@ -1998,6 +1998,36 @@ MutationInfo MemcachedConnection::mutateWithMeta(
     return response.getMutationInfo();
 }
 
+MutationInfo MemcachedConnection::mutateWithMeta(
+        Document& doc,
+        Vbid vbucket,
+        cb::mcbp::request::MutateWithMetaCommand command,
+        uint64_t operation_cas,
+        uint32_t meta_option,
+        uint64_t rev_seqno,
+        std::vector<std::size_t> cas_offsets,
+        std::vector<std::size_t> seqno_offsets,
+        const GetFrameInfoFunction& getFrameInfo) {
+    BinprotMutateWithMetaCommand cmd(doc,
+                                     vbucket,
+                                     command,
+                                     operation_cas,
+                                     meta_option,
+                                     rev_seqno,
+                                     std::move(cas_offsets),
+                                     std::move(seqno_offsets));
+    applyFrameInfos(cmd, getFrameInfo);
+
+    const auto response = BinprotMutationResponse(execute(cmd));
+    if (!response.isSuccess()) {
+        throw ConnectionError(
+                fmt::format("Failed to mutateWithMeta {}", doc.info.id),
+                response);
+    }
+
+    return response.getMutationInfo();
+}
+
 ObserveInfo MemcachedConnection::observeSeqno(
         Vbid vbid, uint64_t uuid, const GetFrameInfoFunction& getFrameInfo) {
     BinprotObserveSeqnoCommand observe(vbid, uuid);

--- a/protocol/connection/client_connection.h
+++ b/protocol/connection/client_connection.h
@@ -13,6 +13,7 @@
 #include <fmt/ostream.h>
 #include <folly/Synchronized.h>
 #include <folly/io/async/DelayedDestruction.h>
+#include <mcbp/codec/with_meta_options.h>
 #include <memcached/bucket_type.h>
 #include <memcached/engine_error.h>
 #include <memcached/protocol_binary.h>
@@ -39,6 +40,7 @@ class Builder;
 }
 namespace cb::mcbp::request {
 class FrameInfo;
+enum class MutateWithMetaCommand;
 }
 
 using FrameInfoVector =
@@ -950,6 +952,38 @@ public:
                                 uint32_t metaOption,
                                 std::vector<uint8_t> metaExtras = {},
                                 const GetFrameInfoFunction& getFrameInfo = {});
+
+    MutationInfo mutateWithMeta(
+            Document& doc,
+            Vbid vbucket,
+            cb::mcbp::request::MutateWithMetaCommand command,
+            uint64_t operation_cas,
+            uint32_t meta_option,
+            uint64_t rev_seqno,
+            std::vector<std::size_t> cas_offsets = {},
+            std::vector<std::size_t> seqno_offsets = {},
+            const GetFrameInfoFunction& getFrameInfo = {});
+
+    MutationInfo mutateWithMeta(
+            Document& doc,
+            Vbid vbucket,
+            cb::mcbp::request::MutateWithMetaCommand command,
+            uint64_t operation_cas,
+            cb::mcbp::WithMetaOptions meta_option,
+            uint64_t rev_seqno,
+            std::vector<std::size_t> cas_offsets = {},
+            std::vector<std::size_t> seqno_offsets = {},
+            const GetFrameInfoFunction& getFrameInfo = {}) {
+        return mutateWithMeta(doc,
+                              vbucket,
+                              command,
+                              operation_cas,
+                              meta_option.encode(),
+                              rev_seqno,
+                              std::move(cas_offsets),
+                              std::move(seqno_offsets),
+                              getFrameInfo);
+    }
 
     /**
      * Call GetMeta for the provided document in the provided vbucket.

--- a/protocol/connection/client_mcbp_commands.cc
+++ b/protocol/connection/client_mcbp_commands.cc
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
  *     Copyright 2016-Present Couchbase, Inc.
  *
@@ -12,8 +11,12 @@
 #include <dek/manager.h>
 #include <gsl/gsl-lite.hpp>
 #include <mcbp/codec/frameinfo.h>
+#include <mcbp/codec/mutate_with_meta_payload.h>
+#include <mcbp/codec/with_meta_options.h>
 #include <mcbp/mcbp.h>
 #include <memcached/tracer.h>
+#include <platform/string_hex.h>
+
 #include <array>
 #include <utility>
 
@@ -1916,6 +1919,51 @@ void BinprotDelWithMetaCommand::encode(std::vector<uint8_t>& buf) const {
     buf.insert(buf.end(), extraBuf.begin(), extraBuf.end());
     buf.insert(buf.end(), key.begin(), key.end());
     buf.insert(buf.end(), doc.value.begin(), doc.value.end());
+}
+
+BinprotMutateWithMetaCommand::BinprotMutateWithMetaCommand(
+        Document document,
+        Vbid vbucket,
+        cb::mcbp::request::MutateWithMetaCommand command,
+        uint64_t operation_cas,
+        uint32_t meta_option,
+        uint64_t rev_seqno,
+        std::vector<std::size_t> cas_offsets,
+        std::vector<std::size_t> seqno_offsets)
+    : BinprotGenericCommand(cb::mcbp::ClientOpcode::MutateWithMeta,
+                            document.info.id),
+      doc(std::move(document)) {
+    const auto options = cb::mcbp::WithMetaOptions(meta_option);
+    cb::mcbp::request::MutateWithMetaPayload payload;
+    payload.flags = doc.info.flags;
+    payload.exptime = doc.info.expiration;
+    if (rev_seqno != DEFAULT_REV_SEQ_NUM) {
+        payload.rev_seqno = rev_seqno;
+    }
+    if (options.generate_cas != GenerateCas::Yes) {
+        payload.cas = doc.info.cas;
+    }
+    payload.options = meta_option;
+    payload.command = command;
+    payload.cas_offsets = std::move(cas_offsets);
+    payload.seqno_offsets = std::move(seqno_offsets);
+    extras = payload;
+
+    setVBucket(vbucket);
+    setCas(operation_cas);
+    setDatatype(doc.info.datatype);
+}
+
+void BinprotMutateWithMetaCommand::encode(std::vector<uint8_t>& buf) const {
+    std::string meta = extras.dump();
+    uint32_t meta_len = htonl(static_cast<uint32_t>(meta.size()));
+    writeHeader(buf, doc.value.size() + meta.size(), sizeof(meta_len));
+    buf.insert(buf.end(),
+               reinterpret_cast<uint8_t*>(&meta_len),
+               reinterpret_cast<uint8_t*>(&meta_len) + sizeof(meta_len));
+    buf.insert(buf.end(), key.begin(), key.end());
+    buf.insert(buf.end(), doc.value.begin(), doc.value.end());
+    buf.insert(buf.end(), meta.begin(), meta.end());
 }
 
 BinprotReturnMetaCommand::BinprotReturnMetaCommand(

--- a/protocol/connection/client_mcbp_commands.h
+++ b/protocol/connection/client_mcbp_commands.h
@@ -988,6 +988,25 @@ protected:
     cb::mcbp::request::DelWithMetaPayload extras;
 };
 
+class BinprotMutateWithMetaCommand : public BinprotGenericCommand {
+public:
+    BinprotMutateWithMetaCommand(
+            Document doc,
+            Vbid vbucket,
+            cb::mcbp::request::MutateWithMetaCommand command,
+            uint64_t operation_cas,
+            uint32_t meta_option,
+            uint64_t rev_seqno,
+            std::vector<std::size_t> cas_offsets,
+            std::vector<std::size_t> seqno_offsets);
+
+    void encode(std::vector<uint8_t>& buf) const override;
+
+protected:
+    const Document doc;
+    nlohmann::json extras;
+};
+
 class BinprotReturnMetaCommand : public BinprotGenericCommand {
 public:
     BinprotReturnMetaCommand(cb::mcbp::request::ReturnMetaType type,

--- a/protocol/mcbp/CMakeLists.txt
+++ b/protocol/mcbp/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(mcbp STATIC
             json_utilities.cc
             lldb_dump_parser.cc
             magic.cc
+            mutate_with_meta_payload.cc
             opcode.cc
             request.cc
             response.cc
@@ -60,6 +61,7 @@ cb_add_test_executable(mcbp_unit_tests
                json_utilities_test.cc
                magic_test.cc
                mcbp_dump_parser_test.cc
+               mutate_with_meta_payload_test.cc
                request_test.cc
                sla_test.cc)
 kv_enable_pch(mcbp_unit_tests)

--- a/protocol/mcbp/feature.cc
+++ b/protocol/mcbp/feature.cc
@@ -87,6 +87,8 @@ std::string cb::mcbp::format_as(Feature feature) {
         return "GetRandomKeyIncludeXattr";
     case Feature::SubdocAllowReplicaReadOnDeletedDocs:
         return "SubdocAllowReplicaReadOnDeletedDocs";
+    case Feature::MutateWithMeta:
+        return "MutateWithMeta";
     }
 
     return fmt::format("unknown_{:#x}", static_cast<uint16_t>(feature));

--- a/protocol/mcbp/feature_test.cc
+++ b/protocol/mcbp/feature_test.cc
@@ -58,7 +58,8 @@ const std::map<cb::mcbp::Feature, std::string> featureBlueprint = {
          {cb::mcbp::Feature::GetRandomKeyIncludeXattr,
           "GetRandomKeyIncludeXattr"},
          {cb::mcbp::Feature::SubdocAllowReplicaReadOnDeletedDocs,
-          "SubdocAllowReplicaReadOnDeletedDocs"}}};
+          "SubdocAllowReplicaReadOnDeletedDocs"},
+         {cb::mcbp::Feature::MutateWithMeta, "MutateWithMeta"}}};
 
 TEST(to_string, LegalValues) {
     for (const auto& [feature, name] : featureBlueprint) {

--- a/protocol/mcbp/mutate_with_meta_payload.cc
+++ b/protocol/mcbp/mutate_with_meta_payload.cc
@@ -1,0 +1,97 @@
+/*
+ *     Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Use of this software is governed by the Business Source License included
+ *   in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ *   in that file, in accordance with the Business Source License, use of this
+ *   software will be governed by the Apache License, Version 2.0, included in
+ *   the file licenses/APL2.txt.
+ */
+
+#include <mcbp/codec/mutate_with_meta_payload.h>
+#include <nlohmann/json.hpp>
+#include <platform/string_hex.h>
+#include <utilities/json_utilities.h>
+
+namespace cb::mcbp::request {
+void to_json(nlohmann::json& json, const MutateWithMetaCommand& cmd) {
+    switch (cmd) {
+    case MutateWithMetaCommand::Add:
+        json = "add";
+        return;
+    case MutateWithMetaCommand::Set:
+        json = "set";
+        return;
+    case MutateWithMetaCommand::Delete:
+        json = "delete";
+        return;
+    }
+    throw std::invalid_argument("Unknown MutateWithMetaCommand");
+}
+
+void from_json(const nlohmann::json& json, MutateWithMetaCommand& cmd) {
+    auto str = json.get<std::string>();
+    if (str == "add") {
+        cmd = MutateWithMetaCommand::Add;
+        return;
+    }
+    if (str == "set") {
+        cmd = MutateWithMetaCommand::Set;
+        return;
+    }
+    if (str == "delete") {
+        cmd = MutateWithMetaCommand::Delete;
+        return;
+    }
+    throw std::invalid_argument("Unknown MutateWithMetaCommand: " + str);
+}
+
+void to_json(nlohmann::json& json, const MutateWithMetaPayload& payload) {
+    json = nlohmann::json{
+            {"command", payload.command},
+            {"cas", cb::to_hex(payload.cas.value_or(0))},
+            {"rev_seqno", cb::to_hex(payload.rev_seqno.value_or(0))},
+            {"flags", cb::to_hex(payload.flags)},
+            {"expiration", cb::to_hex(payload.exptime)},
+            {"options", cb::to_hex(payload.options.encode())},
+            {"cas_offsets", payload.cas_offsets},
+            {"seqno_offsets", payload.seqno_offsets}};
+    if (!payload.cas.has_value()) {
+        json.erase("cas");
+    }
+    if (!payload.rev_seqno.has_value()) {
+        json.erase("rev_seqno");
+    }
+    if (payload.cas_offsets.empty()) {
+        json.erase("cas_offsets");
+    }
+    if (payload.seqno_offsets.empty()) {
+        json.erase("seqno_offsets");
+    }
+}
+
+void from_json(const nlohmann::json& json, MutateWithMetaPayload& payload) {
+    payload.command = json.at("command").get<MutateWithMetaCommand>();
+    if (json.contains("cas")) {
+        payload.cas = cb::getValueFromJson<uint64_t>(json, "cas");
+    }
+    if (json.contains("rev_seqno")) {
+        payload.rev_seqno = cb::getValueFromJson<uint64_t>(json, "rev_seqno");
+    }
+
+    payload.flags = cb::getValueFromJson<uint32_t>(json, "flags");
+    payload.exptime = cb::getValueFromJson<uint32_t>(json, "expiration");
+    payload.options =
+            WithMetaOptions{cb::getValueFromJson<uint32_t>(json, "options")};
+
+    if (json.contains("cas_offsets")) {
+        payload.cas_offsets =
+                json.at("cas_offsets").get<std::vector<std::size_t>>();
+    }
+    if (json.contains("seqno_offsets")) {
+        payload.seqno_offsets =
+                json.at("seqno_offsets").get<std::vector<std::size_t>>();
+    }
+}
+
+} // namespace cb::mcbp::request

--- a/protocol/mcbp/mutate_with_meta_payload_test.cc
+++ b/protocol/mcbp/mutate_with_meta_payload_test.cc
@@ -1,0 +1,259 @@
+/*
+ *     Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Use of this software is governed by the Business Source License included
+ *   in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ *   in that file, in accordance with the Business Source License, use of this
+ *   software will be governed by the Apache License, Version 2.0, included in
+ *   the file licenses/APL2.txt.
+ */
+
+#include <folly/portability/GTest.h>
+#include <mcbp/codec/mutate_with_meta_payload.h>
+#include <nlohmann/json.hpp>
+
+using namespace cb::mcbp::request;
+using namespace cb::mcbp;
+
+TEST(MutateWithMetaCommandTest, to_json_add) {
+    nlohmann::json json = MutateWithMetaCommand::Add;
+    EXPECT_EQ(json.get<std::string>(), "add");
+}
+
+TEST(MutateWithMetaCommandTest, to_json_set) {
+    nlohmann::json json = MutateWithMetaCommand::Set;
+    EXPECT_EQ(json.get<std::string>(), "set");
+}
+
+TEST(MutateWithMetaCommandTest, to_json_delete) {
+    nlohmann::json json = MutateWithMetaCommand::Delete;
+    EXPECT_EQ(json.get<std::string>(), "delete");
+}
+
+TEST(MutateWithMetaCommandTest, to_json_invalid) {
+    try {
+        nlohmann::json json = static_cast<MutateWithMetaCommand>(0xff);
+        FAIL() << "Expected to_json to throw for invalid command";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "Unknown MutateWithMetaCommand");
+    }
+}
+
+TEST(MutateWithMetaCommandTest, from_json_add) {
+    nlohmann::json json = "add";
+    EXPECT_EQ(MutateWithMetaCommand::Add, json);
+}
+
+TEST(MutateWithMetaCommandTest, from_json_set) {
+    nlohmann::json json = "set";
+    EXPECT_EQ(MutateWithMetaCommand::Set, json);
+}
+
+TEST(MutateWithMetaCommandTest, from_json_delete) {
+    nlohmann::json json = "delete";
+    EXPECT_EQ(MutateWithMetaCommand::Delete, json);
+}
+
+TEST(MutateWithMetaCommandTest, from_json_invalid) {
+    try {
+        nlohmann::json json = "unknown";
+        (void)json.get<MutateWithMetaCommand>();
+        FAIL() << "Expected from_json to throw for invalid command";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_STREQ(e.what(), "Unknown MutateWithMetaCommand: unknown");
+    }
+}
+
+TEST(MutateWithMetaPayloadTest, to_json_basic) {
+    MutateWithMetaPayload payload;
+    payload.command = MutateWithMetaCommand::Set;
+    payload.cas = 0x1122334455667788ull;
+    payload.rev_seqno = 0x12345678;
+    payload.flags = 0xdeadbeef;
+    payload.exptime = 3600;
+    payload.options = WithMetaOptions{0x04};
+
+    nlohmann::json json;
+    to_json(json, payload);
+
+    EXPECT_EQ(json["command"].get<std::string>(), "set");
+    EXPECT_EQ(json["cas"].get<std::string>(), "0x1122334455667788");
+    EXPECT_EQ(json["rev_seqno"].get<std::string>(), "0x0000000012345678");
+    EXPECT_EQ(json["flags"].get<std::string>(), "0xdeadbeef");
+    EXPECT_EQ(json["expiration"].get<std::string>(), "0x00000e10");
+    EXPECT_EQ(json["options"].get<std::string>(), "0x00000004");
+    EXPECT_FALSE(json.contains("cas_offsets"));
+    EXPECT_FALSE(json.contains("seqno_offsets"));
+}
+
+TEST(MutateWithMetaPayloadTest, to_json_with_offsets) {
+    MutateWithMetaPayload payload;
+    payload.command = MutateWithMetaCommand::Set;
+    payload.cas = 0x1;
+    payload.cas_offsets = {10, 50, 100};
+    payload.seqno_offsets = {30, 70, 120};
+
+    nlohmann::json json;
+    to_json(json, payload);
+
+    EXPECT_EQ(json["cas_offsets"].get<std::vector<std::size_t>>(),
+              (std::vector<std::size_t>{10, 50, 100}));
+    EXPECT_EQ(json["seqno_offsets"].get<std::vector<std::size_t>>(),
+              (std::vector<std::size_t>{30, 70, 120}));
+}
+
+TEST(MutateWithMetaPayloadTest, to_json_without_optional_fields) {
+    MutateWithMetaPayload payload;
+    payload.command = MutateWithMetaCommand::Set;
+    payload.flags = 0x12345678;
+    payload.exptime = 7200;
+    payload.options = WithMetaOptions{0x0c};
+
+    nlohmann::json json;
+    to_json(json, payload);
+
+    EXPECT_FALSE(json.contains("cas"));
+    EXPECT_FALSE(json.contains("rev_seqno"));
+    EXPECT_FALSE(json.contains("cas_offsets"));
+    EXPECT_FALSE(json.contains("seqno_offsets"));
+}
+
+TEST(MutateWithMetaPayloadTest, from_json_basic) {
+    nlohmann::json json = {{"command", "set"},
+                           {"cas", "0x1122334455667788"},
+                           {"rev_seqno", "0x12345678"},
+                           {"flags", "0xdeadbeef"},
+                           {"expiration", "3600"},
+                           {"options", "0x0c"}};
+
+    MutateWithMetaPayload payload;
+    from_json(json, payload);
+
+    EXPECT_EQ(payload.command, MutateWithMetaCommand::Set);
+    EXPECT_EQ(payload.cas.value(), 0x1122334455667788ull);
+    EXPECT_EQ(payload.rev_seqno.value(), 0x12345678);
+    EXPECT_EQ(payload.flags, 0xdeadbeef);
+    EXPECT_EQ(payload.exptime, 3600);
+    EXPECT_EQ(payload.options.encode(), 0x0c);
+    EXPECT_TRUE(payload.cas_offsets.empty());
+    EXPECT_TRUE(payload.seqno_offsets.empty());
+}
+
+TEST(MutateWithMetaPayloadTest, from_json_with_offsets) {
+    nlohmann::json json = {{"command", "delete"},
+                           {"cas", "0x1"},
+                           {"flags", "0x2"},
+                           {"expiration", "0x3"},
+                           {"options", "0x4"},
+                           {"cas_offsets", {10, 50, 100}},
+                           {"seqno_offsets", {30, 70, 120}}};
+
+    MutateWithMetaPayload payload;
+    from_json(json, payload);
+
+    EXPECT_EQ(payload.command, MutateWithMetaCommand::Delete);
+    EXPECT_EQ(payload.cas.value(), 1);
+    EXPECT_EQ(payload.flags, 2);
+    EXPECT_EQ(payload.exptime, 3);
+    EXPECT_EQ(payload.options.encode(), 4);
+    EXPECT_EQ(payload.cas_offsets, (std::vector<std::size_t>{10, 50, 100}));
+    EXPECT_EQ(payload.seqno_offsets, (std::vector<std::size_t>{30, 70, 120}));
+}
+
+TEST(MutateWithMetaPayloadTest, from_json_without_optional_fields) {
+    nlohmann::json json = {{"command", "add"},
+                           {"flags", "0x1234"},
+                           {"expiration", "0x10"},
+                           {"options", "0x04"}};
+
+    MutateWithMetaPayload payload;
+    from_json(json, payload);
+
+    EXPECT_EQ(payload.command, MutateWithMetaCommand::Add);
+    EXPECT_FALSE(payload.cas.has_value());
+    EXPECT_FALSE(payload.rev_seqno.has_value());
+    EXPECT_EQ(payload.flags, 0x1234);
+    EXPECT_EQ(payload.exptime, 0x10);
+    EXPECT_EQ(payload.options.encode(), 0x04);
+    EXPECT_TRUE(payload.cas_offsets.empty());
+    EXPECT_TRUE(payload.seqno_offsets.empty());
+}
+
+TEST(MutateWithMetaPayloadTest, from_json_missing_required_field) {
+    nlohmann::json json = {
+            {"command", "set"}, {"flags", "0x1234"}, {"options", "0x04"}};
+
+    try {
+        MutateWithMetaPayload payload = json;
+    } catch (const std::exception& e) {
+        EXPECT_STREQ(
+                e.what(),
+                "cb::getValueFromJson(): Missing required field: expiration");
+    }
+}
+
+TEST(MutateWithMetaPayloadTest, round_trip_minimal) {
+    MutateWithMetaPayload original;
+    original.command = MutateWithMetaCommand::Set;
+    original.flags = 0xdeadbeef;
+    original.exptime = 3600;
+    original.options = WithMetaOptions{0x04};
+
+    nlohmann::json json;
+    to_json(json, original);
+
+    MutateWithMetaPayload decoded;
+    from_json(json, decoded);
+
+    EXPECT_EQ(decoded.command, original.command);
+    EXPECT_EQ(decoded.cas, original.cas);
+    EXPECT_EQ(decoded.rev_seqno, original.rev_seqno);
+    EXPECT_EQ(decoded.flags, original.flags);
+    EXPECT_EQ(decoded.exptime, original.exptime);
+    EXPECT_EQ(decoded.options.encode(), original.options.encode());
+    EXPECT_EQ(decoded.cas_offsets, original.cas_offsets);
+    EXPECT_EQ(decoded.seqno_offsets, original.seqno_offsets);
+}
+
+TEST(MutateWithMetaPayloadTest, round_trip_complete) {
+    MutateWithMetaPayload original;
+    original.command = MutateWithMetaCommand::Delete;
+    original.cas = 0x8877665544332211ull;
+    original.rev_seqno = 0x99887766;
+    original.flags = 0xaabbccdd;
+    original.exptime = 7200;
+    original.options = WithMetaOptions{0x1c};
+    original.cas_offsets = {10, 50, 100};
+    original.seqno_offsets = {30, 70, 120};
+
+    nlohmann::json json;
+    to_json(json, original);
+
+    MutateWithMetaPayload decoded;
+    from_json(json, decoded);
+
+    EXPECT_EQ(decoded.command, original.command);
+    EXPECT_EQ(decoded.cas, original.cas);
+    EXPECT_EQ(decoded.rev_seqno, original.rev_seqno);
+    EXPECT_EQ(decoded.flags, original.flags);
+    EXPECT_EQ(decoded.exptime, original.exptime);
+    EXPECT_EQ(decoded.options.encode(), original.options.encode());
+    EXPECT_EQ(decoded.cas_offsets, original.cas_offsets);
+    EXPECT_EQ(decoded.seqno_offsets, original.seqno_offsets);
+}
+
+TEST(MutateWithMetaPayloadTest, from_json_decimal_numbers) {
+    nlohmann::json json = {{"command", "set"},
+                           {"cas", 123456789},
+                           {"rev_seqno", 987654321},
+                           {"flags", 0x12345678},
+                           {"expiration", 3600},
+                           {"options", 0x04}};
+
+    MutateWithMetaPayload payload;
+    from_json(json, payload);
+
+    EXPECT_EQ(payload.command, MutateWithMetaCommand::Set);
+    EXPECT_EQ(payload.cas.value(), 123456789ull);
+    EXPECT_EQ(payload.rev_seqno.value(), 987654321ull);
+}

--- a/protocol/mcbp/opcode.cc
+++ b/protocol/mcbp/opcode.cc
@@ -449,6 +449,12 @@ public:
                 Attribute::Reorder,
                 Attribute::Collection,
                 Attribute::SubjectForThrottling}});
+        setup(ClientOpcode::MutateWithMeta,
+              {"MUTATE_WITH_META"sv,
+               {Attribute::Supported,
+                Attribute::Reorder,
+                Attribute::Collection,
+                Attribute::SubjectForThrottling}});
         setup(ClientOpcode::DcpOpen, {"DCP_OPEN"sv, {Attribute::Supported}});
         setup(ClientOpcode::DcpAddStream,
               {"DCP_ADD_STREAM"sv, {Attribute::Supported}});

--- a/protocol/mcbp/request.cc
+++ b/protocol/mcbp/request.cc
@@ -294,6 +294,7 @@ nlohmann::json Request::to_json(bool validated) const {
         switch (getClientOpcode()) {
         case ClientOpcode::GetEx:
         case ClientOpcode::GetExReplica:
+        case ClientOpcode::MutateWithMeta:
         case ClientOpcode::Get:
         case ClientOpcode::Getq:
         case ClientOpcode::Getk:

--- a/protocol/mcbp/with_meta_options.cc
+++ b/protocol/mcbp/with_meta_options.cc
@@ -35,7 +35,7 @@ WithMetaOptions::WithMetaOptions(uint32_t options) {
     }
 }
 
-uint32_t WithMetaOptions::encode() {
+uint32_t WithMetaOptions::encode() const {
     uint32_t options = 0;
 
     if (check_conflicts == CheckConflicts::No) {

--- a/tests/testapp/testapp.cc
+++ b/tests/testapp/testapp.cc
@@ -1203,7 +1203,8 @@ MemcachedConnection& TestappTest::prepare(MemcachedConnection& connection) {
              cb::mcbp::Feature::SELECT_BUCKET,
              cb::mcbp::Feature::SubdocReplaceBodyWithXattr,
              cb::mcbp::Feature::SubdocAllowsAccessOnMultipleXattrKeys,
-             cb::mcbp::Feature::SubdocBinaryXattr}};
+             cb::mcbp::Feature::SubdocBinaryXattr,
+             cb::mcbp::Feature::MutateWithMeta}};
     switch (hasSnappySupport()) {
     case ClientSnappySupport::Everywhere:
         features.push_back(cb::mcbp::Feature::SnappyEverywhere);

--- a/tests/testapp/testapp_withmeta.cc
+++ b/tests/testapp/testapp_withmeta.cc
@@ -11,9 +11,23 @@
 #include "testapp.h"
 #include "testapp_client_test.h"
 
+#include <mcbp/codec/mutate_with_meta_payload.h>
+#include <platform/string_hex.h>
 #include <protocol/connection/client_mcbp_commands.h>
 #include <xattr/blob.h>
 #include <xattr/utils.h>
+
+/// Find all offsets of a pattern in a string
+static std::vector<std::size_t> findAllOffsets(std::string_view haystack,
+                                               std::string_view needle) {
+    std::vector<std::size_t> offsets;
+    std::size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string_view::npos) {
+        offsets.push_back(pos);
+        pos += needle.size();
+    }
+    return offsets;
+}
 
 class WithMetaTest : public TestappXattrClientTest {
 public:
@@ -388,6 +402,511 @@ TEST_P(WithMetaTest, DeleteWithMetaRejectsBody_AllowValuePruning_DTXattr) {
 
 TEST_P(WithMetaTest, DeleteWithMetaRejectsBody_DTXattr) {
     testDeleteWithMetaRejectsBody(false, true);
+}
+
+TEST_P(WithMetaTest, MutateWithMeta) {
+    using namespace cb::mcbp;
+    using namespace cb::mcbp::subdoc;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+
+    cb::xattr::Blob blob;
+    blob.set("user",
+             R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    blob.set("_sys",
+             R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    const auto xattrs = blob.finalize();
+    doc.value.clear();
+    std::ranges::copy(xattrs, std::back_inserter(doc.value));
+    doc.value.append(
+            R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    doc.info.datatype = static_cast<cb::mcbp::Datatype>(
+            PROTOCOL_BINARY_DATATYPE_XATTR | PROTOCOL_BINARY_DATATYPE_JSON);
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+
+    // Find offsets for CAS and seqno replacement within the xattrs section only
+    auto xattr_section =
+            doc.value.substr(0, cb::xattr::get_body_offset(doc.value));
+    auto cas_offsets = findAllOffsets(xattr_section, "1xffffffffffffffff");
+    auto seqno_offsets = findAllOffsets(xattr_section, "1xfffffffffffffffe");
+
+    auto info = userConnection->mutateWithMeta(
+            doc,
+            Vbid{0},
+            cb::mcbp::request::MutateWithMetaCommand::Add,
+            cb::mcbp::cas::Wildcard,
+            REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+            1,
+            cas_offsets,
+            seqno_offsets);
+
+    auto validateDocument = [this, &info]() {
+        BinprotSubdocMultiLookupCommand cmd{
+                name,
+                {
+                        {ClientOpcode::SubdocGet,
+                         PathFlag::XattrPath,
+                         "$document"},
+                        {ClientOpcode::SubdocGet, PathFlag::XattrPath, "user"},
+                        {ClientOpcode::SubdocGet, PathFlag::XattrPath, "_sys"},
+                        {ClientOpcode::SubdocGet, PathFlag::None, "CAS"},
+                        {ClientOpcode::SubdocGet, PathFlag::None, "seqno"},
+                },
+                DocFlag::None};
+
+        const auto resp =
+                BinprotSubdocMultiLookupResponse(userConnection->execute(cmd));
+        ASSERT_EQ(Status::Success, resp.getStatus());
+
+        // Ensure that the CAS is equal:
+        EXPECT_EQ(info.cas, resp.getCas());
+        auto results = resp.getResults();
+        EXPECT_EQ(Status::Success, results[0].status);
+        nlohmann::json meta = nlohmann::json::parse(results[0].value);
+        EXPECT_EQ(Status::Success, results[1].status);
+        nlohmann::json user = nlohmann::json::parse(results[1].value);
+        // So this is a bit of a mess.. using macro-expansion will store the
+        // cas in network byte order.. but returned from $document it is in
+        // host byte order...
+        EXPECT_EQ(user["CAS"].get<std::string>(),
+                  cb::to_hex(htonll(
+                          cb::from_hex(meta["CAS"].get<std::string>()))));
+        EXPECT_EQ(user["CAS"].get<std::string>(), cb::to_hex(htonll(info.cas)));
+        EXPECT_EQ(user["seqno"].get<std::string>(),
+                  meta["seqno"].get<std::string>());
+        EXPECT_EQ(user["seqno"].get<std::string>(), cb::to_hex(info.seqno));
+        EXPECT_EQ(Status::Success, results[2].status);
+        nlohmann::json sys = nlohmann::json::parse(results[2].value);
+        EXPECT_EQ(sys["CAS"].get<std::string>(),
+                  cb::to_hex(htonll(
+                          cb::from_hex(meta["CAS"].get<std::string>()))));
+        EXPECT_EQ(sys["CAS"].get<std::string>(), cb::to_hex(htonll(info.cas)));
+        EXPECT_EQ(sys["seqno"].get<std::string>(),
+                  meta["seqno"].get<std::string>());
+        // The fields in the body should not have been touched.
+        EXPECT_EQ(Status::Success, results[3].status);
+        EXPECT_EQ(R"("1xffffffffffffffff")", results[3].value);
+        EXPECT_EQ(Status::Success, results[4].status);
+        EXPECT_EQ(R"("1xfffffffffffffffe")", results[4].value);
+    };
+
+    validateDocument();
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                cb::mcbp::request::MutateWithMetaCommand::Add,
+                cb::mcbp::cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                cas_offsets,
+                seqno_offsets);
+        FAIL() << "Expected a key exists error";
+    } catch (const ConnectionError& error) {
+        EXPECT_EQ(cb::mcbp::Status::KeyEexists, error.getReason());
+    }
+
+    // but we should be able to replace it (using cas)
+    info = userConnection->mutateWithMeta(
+            doc,
+            Vbid{0},
+            cb::mcbp::request::MutateWithMetaCommand::Set,
+            info.cas,
+            REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+            1,
+            cas_offsets,
+            seqno_offsets);
+
+    validateDocument();
+
+    // But fail if the cas is incorrect
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                cb::mcbp::request::MutateWithMetaCommand::Set,
+                info.cas + 1,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                cas_offsets,
+                seqno_offsets);
+        FAIL() << "Expected a key exists error";
+    } catch (const ConnectionError& error) {
+        EXPECT_EQ(cb::mcbp::Status::KeyEexists, error.getReason());
+    }
+
+    // But succeed with unconditional set
+    info = userConnection->mutateWithMeta(
+            doc,
+            Vbid{0},
+            cb::mcbp::request::MutateWithMetaCommand::Set,
+            cb::mcbp::cas::Wildcard,
+            REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+            1,
+            cas_offsets,
+            seqno_offsets);
+
+    validateDocument();
+
+    blob.prune_user_keys();
+    const auto system_xattrs = blob.finalize();
+    doc.value.clear();
+    std::ranges::copy(system_xattrs, std::back_inserter(doc.value));
+
+    // Recalculate offsets for the reduced document
+    xattr_section = doc.value.substr(0, cb::xattr::get_body_offset(doc.value));
+    cas_offsets = findAllOffsets(xattr_section, "1xffffffffffffffff");
+    seqno_offsets = findAllOffsets(xattr_section, "1xfffffffffffffffe");
+
+    // and we can delete it
+    info = userConnection->mutateWithMeta(
+            doc,
+            Vbid{0},
+            cb::mcbp::request::MutateWithMetaCommand::Delete,
+            cb::mcbp::cas::Wildcard,
+            REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+            1,
+            cas_offsets,
+            seqno_offsets);
+
+    BinprotSubdocMultiLookupCommand cmd{
+            name,
+            {{ClientOpcode::SubdocGet, PathFlag::XattrPath, "$document"},
+             {ClientOpcode::SubdocGet, PathFlag::XattrPath, "_sys"}},
+            DocFlag::AccessDeleted};
+
+    auto resp = BinprotSubdocMultiLookupResponse(userConnection->execute(cmd));
+    ASSERT_EQ(cb::mcbp::Status::SubdocSuccessDeleted, resp.getStatus());
+
+    // Ensure that the CAS is equal:
+    EXPECT_EQ(info.cas, resp.getCas());
+    auto results = resp.getResults();
+    EXPECT_EQ(cb::mcbp::Status::Success, results[0].status);
+    nlohmann::json meta = nlohmann::json::parse(results[0].value);
+    EXPECT_EQ(cb::mcbp::Status::Success, results[1].status);
+    nlohmann::json sys = nlohmann::json::parse(results[1].value);
+    EXPECT_EQ(sys["CAS"].get<std::string>(),
+              cb::to_hex(htonll(cb::from_hex(meta["CAS"].get<std::string>()))));
+    EXPECT_EQ(sys["CAS"].get<std::string>(), cb::to_hex(htonll(info.cas)));
+    EXPECT_EQ(sys["seqno"].get<std::string>(),
+              meta["seqno"].get<std::string>());
+}
+
+TEST_P(WithMetaTest, MutateWithMetaInvalidOffsets) {
+    using namespace cb::mcbp;
+    using namespace cb::mcbp::subdoc;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+
+    cb::xattr::Blob blob;
+    blob.set("user",
+             R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    blob.set("_sys",
+             R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    const auto xattrs = blob.finalize();
+    doc.value.clear();
+    std::ranges::copy(xattrs, std::back_inserter(doc.value));
+    doc.value.append(
+            R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    doc.info.datatype = static_cast<cb::mcbp::Datatype>(
+            PROTOCOL_BINARY_DATATYPE_XATTR | PROTOCOL_BINARY_DATATYPE_JSON);
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+    std::vector<std::size_t> cas_offsets = {{2, 3, 4}};
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                cb::mcbp::request::MutateWithMetaCommand::Add,
+                cb::mcbp::cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                cas_offsets,
+                {});
+        FAIL() << "Expected mutateWithMeta to throw due to invalid offsets";
+    } catch (const ConnectionError& error) {
+        EXPECT_TRUE(error.isInvalidArguments())
+                << "mutateWithMeta threw an unexpected exception: "
+                << error.what();
+        EXPECT_EQ("Patching seqno and cas would garble the xattr section",
+                  error.getErrorContext());
+    }
+}
+
+TEST_P(WithMetaTest, MutateWithMetaCasOffsetOutOfBounds) {
+    using namespace cb::mcbp;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+    cb::xattr::Blob blob;
+    blob.set("user", R"({"CAS":"1xffffffffffffffff"})");
+    const auto xattrs = blob.finalize();
+    doc.value.clear();
+    std::ranges::copy(xattrs, std::back_inserter(doc.value));
+    doc.info.datatype = Datatype::Xattr;
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+
+    // Use an offset that would be beyond the xattr section
+    std::vector<std::size_t> cas_offsets = {1000};
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                request::MutateWithMetaCommand::Add,
+                cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                cas_offsets,
+                {});
+        FAIL() << "Expected mutateWithMeta to throw due to out of bounds "
+                  "CAS offset";
+    } catch (const ConnectionError& error) {
+        EXPECT_TRUE(error.isInvalidArguments()) << error.what();
+        EXPECT_EQ("CAS offset is out of bounds of the xattr section",
+                  error.getErrorContext());
+    }
+}
+
+TEST_P(WithMetaTest, MutateWithMetaSeqnoOffsetOutOfBounds) {
+    using namespace cb::mcbp;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+    cb::xattr::Blob blob;
+    blob.set("user", R"({"seqno":"1xfffffffffffffffe"})");
+    const auto xattrs = blob.finalize();
+    doc.value.clear();
+    std::ranges::copy(xattrs, std::back_inserter(doc.value));
+    doc.info.datatype = Datatype::Xattr;
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+
+    // Use an offset that would be beyond the xattr section
+    std::vector<std::size_t> seqno_offsets = {1000};
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                request::MutateWithMetaCommand::Add,
+                cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                {},
+                seqno_offsets);
+        FAIL() << "Expected mutateWithMeta to throw due to out of bounds "
+                  "seqno offset";
+    } catch (const ConnectionError& error) {
+        EXPECT_TRUE(error.isInvalidArguments()) << error.what();
+        EXPECT_EQ("Seqno offset is out of bounds of the xattr section",
+                  error.getErrorContext());
+    }
+}
+
+TEST_P(WithMetaTest, MutateWithMetaPatternOnEmptyDocument) {
+    using namespace cb::mcbp;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+    doc.value.clear();
+    doc.info.datatype = Datatype::Raw;
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+
+    std::vector<std::size_t> cas_offsets = {0};
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                request::MutateWithMetaCommand::Add,
+                cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                cas_offsets,
+                {});
+        FAIL() << "Expected mutateWithMeta to throw due to empty document";
+    } catch (const ConnectionError& error) {
+        EXPECT_TRUE(error.isInvalidArguments()) << error.what();
+        EXPECT_EQ("Cannot use pattern macros on empty documents",
+                  error.getErrorContext());
+    }
+}
+
+TEST_P(WithMetaTest, MutateWithMetaPatternOnDocumentWithoutXattr) {
+    using namespace cb::mcbp;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+    doc.value = R"({"body":"value"})";
+    doc.info.datatype = Datatype::JSON;
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+
+    std::vector<std::size_t> cas_offsets = {0};
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                request::MutateWithMetaCommand::Add,
+                cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                cas_offsets,
+                {});
+        FAIL() << "Expected mutateWithMeta to throw due to missing xattrs";
+    } catch (const ConnectionError& error) {
+        EXPECT_TRUE(error.isInvalidArguments()) << error.what();
+        EXPECT_EQ("Cannot use pattern macros documents without xattr",
+                  error.getErrorContext());
+    }
+}
+
+TEST_P(WithMetaTest, MutateWithMetaDeleteWithBody) {
+    using namespace cb::mcbp;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+    cb::xattr::Blob blob;
+    blob.set("_sys", R"({"author":"bubba"})");
+    const auto xattrs = blob.finalize();
+    doc.value.clear();
+    std::ranges::copy(xattrs, std::back_inserter(doc.value));
+    doc.value.append("body content");
+    doc.info.datatype = Datatype::Xattr;
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                request::MutateWithMetaCommand::Delete,
+                cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                {},
+                {});
+        FAIL() << "Expected mutateWithMeta to throw due to body in delete";
+    } catch (const ConnectionError& error) {
+        EXPECT_TRUE(error.isInvalidArguments()) << error.what();
+        EXPECT_EQ("Delete with meta: Document cannot have a body",
+                  error.getErrorContext());
+    }
+}
+
+TEST_P(WithMetaTest, MutateWithMetaDeleteWithUserXattrs) {
+    using namespace cb::mcbp;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+    cb::xattr::Blob blob;
+    blob.set("user", R"({"author":"bubba"})");
+    const auto xattrs = blob.finalize();
+    doc.value.clear();
+    std::ranges::copy(xattrs, std::back_inserter(doc.value));
+    doc.info.datatype = Datatype::Xattr;
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                request::MutateWithMetaCommand::Delete,
+                cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                {},
+                {});
+        FAIL() << "Expected mutateWithMeta to throw due to user xattrs in "
+                  "delete";
+    } catch (const ConnectionError& error) {
+        EXPECT_TRUE(error.isInvalidArguments()) << error.what();
+        EXPECT_EQ("Delete with meta: user-xattrs is not allowed",
+                  error.getErrorContext());
+    }
+}
+
+TEST_P(WithMetaTest, MutateWithMetaDeleteWithBodyNoXattr) {
+    using namespace cb::mcbp;
+
+    if (::testing::get<1>(GetParam()) == XattrSupport::No ||
+        ::testing::get<2>(GetParam()) == ClientJSONSupport::No) {
+        GTEST_SKIP();
+    }
+
+    Document doc{};
+    doc.value = "body content";
+    doc.info.datatype = Datatype::Raw;
+    doc.info.id = name;
+    doc.info.cas = 1;
+    doc.info.flags = 0xdeadbeef;
+
+    try {
+        userConnection->mutateWithMeta(
+                doc,
+                Vbid{0},
+                request::MutateWithMetaCommand::Delete,
+                cas::Wildcard,
+                REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                1,
+                {},
+                {});
+        FAIL() << "Expected mutateWithMeta to throw due to body in delete";
+    } catch (const ConnectionError& error) {
+        EXPECT_TRUE(error.isInvalidArguments()) << error.what();
+        EXPECT_EQ("Delete with meta: Document cannot have a body",
+                  error.getErrorContext());
+    }
 }
 
 class WithMetaRegenerateCasTest : public TestappXattrClientTest {

--- a/tests/testapp_cluster/CMakeLists.txt
+++ b/tests/testapp_cluster/CMakeLists.txt
@@ -10,6 +10,7 @@ cb_add_test_executable(cluster_test
                jwt_tests.cc
                main.cc
                misc_tests.cc
+               mutate_with_meta.cc
                out_of_order_tests.cc
                quota_sharing_paging_test.cc
                rbac_tests.cc

--- a/tests/testapp_cluster/mutate_with_meta.cc
+++ b/tests/testapp_cluster/mutate_with_meta.cc
@@ -1,0 +1,173 @@
+/*
+ *     Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Use of this software is governed by the Business Source License included
+ *   in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ *   in that file, in accordance with the Business Source License, use of this
+ *   software will be governed by the Apache License, Version 2.0, included in
+ *   the file licenses/APL2.txt.
+ */
+#include "clustertest.h"
+
+#include <cluster_framework/auth_provider_service.h>
+#include <cluster_framework/bucket.h>
+#include <cluster_framework/cluster.h>
+#include <mcbp/codec/mutate_with_meta_payload.h>
+#include <platform/string_hex.h>
+#include <protocol/connection/client_connection.h>
+#include <protocol/connection/client_mcbp_commands.h>
+#include <xattr/blob.h>
+
+using namespace cb::mcbp;
+using namespace cb::mcbp::subdoc;
+
+class MutateWithMetaTest : public cb::test::ClusterTest {
+protected:
+    void SetUp() override;
+
+    void validateDocument(MemcachedConnection& conn,
+                          bool macro_expansion,
+                          uint64_t expected_cas,
+                          std::optional<uint64_t> rev_seqno = std::nullopt);
+
+    Document doc;
+};
+
+void MutateWithMetaTest::SetUp() {
+    ClusterTest::SetUp();
+    cb::xattr::Blob blob;
+    blob.set("user",
+             R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    blob.set("_sys",
+             R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    const auto xattrs = blob.finalize();
+    std::ranges::copy(xattrs, std::back_inserter(doc.value));
+    doc.value.append(
+            R"({"CAS":"1xffffffffffffffff", "seqno":"1xfffffffffffffffe"})");
+    doc.info.datatype = static_cast<cb::mcbp::Datatype>(
+            PROTOCOL_BINARY_DATATYPE_XATTR | PROTOCOL_BINARY_DATATYPE_JSON);
+    doc.info.id = "StoreItemWithExistingProperties";
+    doc.info.cas = 0xcafefeed;
+    doc.info.flags = 0xdeadbeef;
+    doc.info.expiration = 0;
+
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    std::string name = info->test_case_name();
+    name.append("_");
+    name.append(info->name());
+    std::ranges::replace(name, '/', '_');
+    doc.info.id = std::move(name);
+}
+
+/// Find all offsets of a pattern in a string
+static std::vector<std::size_t> findAllOffsets(std::string_view haystack,
+                                               std::string_view needle) {
+    std::vector<std::size_t> offsets;
+    std::size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string_view::npos) {
+        offsets.push_back(pos);
+        pos += needle.size();
+    }
+    return offsets;
+}
+
+void MutateWithMetaTest::validateDocument(MemcachedConnection& conn,
+                                          bool macro_expansion,
+                                          uint64_t expected_cas,
+                                          std::optional<uint64_t> rev_seqno) {
+    std::string expected_cas_str = cb::to_hex(htonll(expected_cas));
+    std::string hostlocal_expected_cas_str = cb::to_hex(expected_cas);
+
+    BinprotSubdocMultiLookupCommand cmd{
+            doc.info.id,
+            {
+                    {ClientOpcode::SubdocGet, PathFlag::XattrPath, "$document"},
+                    {ClientOpcode::SubdocGet, PathFlag::XattrPath, "user"},
+                    {ClientOpcode::SubdocGet, PathFlag::XattrPath, "_sys"},
+                    {ClientOpcode::SubdocGet, PathFlag::None, "CAS"},
+                    {ClientOpcode::SubdocGet, PathFlag::None, "seqno"},
+            },
+            DocFlag::None};
+
+    const auto resp = BinprotSubdocMultiLookupResponse(conn.execute(cmd));
+    ASSERT_EQ(Status::Success, resp.getStatus());
+
+    // Ensure that the CAS is equal:
+    EXPECT_EQ(expected_cas, resp.getCas());
+    auto results = resp.getResults();
+    ASSERT_EQ(Status::Success, results[0].status);
+    nlohmann::json meta = nlohmann::json::parse(results[0].value);
+    EXPECT_EQ(hostlocal_expected_cas_str, meta["CAS"].get<std::string>());
+    if (rev_seqno) {
+        EXPECT_EQ(*rev_seqno, std::stoull(meta["revid"].get<std::string>()));
+    }
+    ASSERT_EQ(Status::Success, results[1].status);
+    nlohmann::json user = nlohmann::json::parse(results[1].value);
+    if (macro_expansion) {
+        EXPECT_EQ(expected_cas_str, user["CAS"].get<std::string>());
+        EXPECT_EQ(meta["seqno"], user["seqno"].get<std::string>());
+    } else {
+        EXPECT_EQ(user["CAS"].get<std::string>(), "1xffffffffffffffff");
+        EXPECT_EQ(user["seqno"].get<std::string>(), "1xfffffffffffffffe");
+    }
+    ASSERT_EQ(Status::Success, results[2].status);
+    nlohmann::json sys = nlohmann::json::parse(results[2].value);
+    if (macro_expansion) {
+        EXPECT_EQ(expected_cas_str, sys["CAS"].get<std::string>());
+        EXPECT_EQ(meta["seqno"], sys["seqno"].get<std::string>());
+    } else {
+        EXPECT_EQ(sys["CAS"].get<std::string>(), "1xffffffffffffffff");
+        EXPECT_EQ(sys["seqno"].get<std::string>(), "1xfffffffffffffffe");
+    }
+    ASSERT_EQ(Status::Success, results[3].status);
+    EXPECT_EQ(R"("1xffffffffffffffff")", results[3].value);
+    ASSERT_EQ(Status::Success, results[4].status);
+    EXPECT_EQ(R"("1xfffffffffffffffe")", results[4].value);
+}
+
+TEST_F(MutateWithMetaTest, StoreItemWithExistingProperties) {
+    const uint64_t rev_seqno = 100;
+
+    auto bucket = cluster->getBucket("default");
+    auto conn = bucket->getConnection(Vbid(0));
+    conn->authenticate("@admin");
+    conn->selectBucket("default");
+    auto info =
+            conn->mutateWithMeta(doc,
+                                 Vbid{0},
+                                 cb::mcbp::request::MutateWithMetaCommand::Add,
+                                 cb::mcbp::cas::Wildcard,
+                                 cb::mcbp::WithMetaOptions{}.encode(),
+                                 rev_seqno);
+
+    EXPECT_EQ(doc.info.cas, info.cas);
+    validateDocument(*conn, false, doc.info.cas, rev_seqno);
+}
+
+TEST_F(MutateWithMetaTest, StoreItemWithMacroExpansion) {
+    auto bucket = cluster->getBucket("default");
+    auto conn = bucket->getConnection(Vbid(0));
+    conn->authenticate("@admin");
+    conn->selectBucket("default");
+
+    // Find all offsets of the CAS and seqno placeholders in the xattr section
+    auto xattr_section =
+            doc.value.substr(0, cb::xattr::get_body_offset(doc.value));
+    auto cas_offsets = findAllOffsets(xattr_section, "1xffffffffffffffff");
+    auto seqno_offsets = findAllOffsets(xattr_section, "1xfffffffffffffffe");
+
+    const uint64_t rev_seqno = 200;
+    auto info =
+            conn->mutateWithMeta(doc,
+                                 Vbid{0},
+                                 cb::mcbp::request::MutateWithMetaCommand::Set,
+                                 cb::mcbp::cas::Wildcard,
+                                 REGENERATE_CAS | SKIP_CONFLICT_RESOLUTION_FLAG,
+                                 rev_seqno,
+                                 cas_offsets,
+                                 seqno_offsets);
+
+    // The CAS should have been regenerated
+    EXPECT_NE(doc.info.cas, info.cas);
+    validateDocument(*conn, true, info.cas, rev_seqno);
+}

--- a/utilities/json_utilities.h
+++ b/utilities/json_utilities.h
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
  *     Copyright 2018-Present Couchbase, Inc.
  *
@@ -11,7 +10,11 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <nlohmann/json.hpp>
+#include <platform/string_hex.h>
+
+#include <charconv>
 #include <optional>
 
 namespace cb {
@@ -146,4 +149,57 @@ void throwIfWrongType(const std::string& errorKey,
                       const nlohmann::json& object,
                       nlohmann::json::value_t expectedType,
                       const std::string& calledFrom = "");
+
+/**
+ * Helper function to extract a value of type T from a json object
+ * given a key. If the key does not exist or the type is incorrect
+ * an exception is thrown. It allows the number to either be a JSON
+ * number, a string containing a decimal number, or a string containing
+ * a hex number prefixed with "0x".
+ *
+ * @param json the json object to extract from
+ * @param key the key to extract
+ * @return the extracted value
+ * @throws std::logic_error if the key does not exist or if its not a number
+ *                          or string
+ * @throws std::out_of_range if the value won't fit in the provided datatype
+ */
+template <typename T>
+static T getValueFromJson(const nlohmann::json& json, const std::string& key) {
+    if (!json.contains(key)) {
+        throw std::logic_error(
+                "cb::getValueFromJson(): Missing required field: " + key);
+    }
+
+    if (json[key].is_number()) {
+        return json[key].get<T>();
+    }
+
+    if (json[key].is_string()) {
+        std::string value = json[key].get<std::string>();
+        if (value.starts_with("0x")) {
+            return cb::from_hex(value);
+        }
+
+        T ret;
+        const auto [ptr, ec]{std::from_chars(
+                value.data(), value.data() + value.size(), ret)};
+        if (ec != std::errc()) {
+            if (ec == std::errc::result_out_of_range) {
+                throw std::out_of_range(
+                        fmt::format("cb::getValueFromJson(): Value for '{}' "
+                                    "won't fit in the datatype",
+                                    key));
+            }
+            throw std::system_error(std::make_error_code(ec));
+        }
+        return ret;
+    }
+
+    throw std::logic_error(fmt::format(
+            "cb::getValueFromJson(): Field '{}' must be a number: '{}'",
+            key,
+            json[key].dump()));
+}
+
 } // namespace cb


### PR DESCRIPTION
The MutateWithMeta command allows a user to store an item and have parts of the xattr segment being replaced with the actual value for CAS and seqno (just like subdoc allows for).

Subdoc cannot be used for this as there is a max number (it is however configurable) of paths one may operate on in the "multi" versions, but there is no upper limit on the number of xattr paths a document may have (which means that XDCR could encounter a document with more paths than the max configured subdoc path limit).

The command:
- Must be negotiated via HELLO (feature MutateWithMeta)
- Supports Add, Set, and Delete operations
- Uses JSON-encoded metadata appended to the value (length in 4-byte extras)
- Allows specifying byte offsets where CAS/seqno values should be written
- Supports the same options as existing WithMeta commands

Change-Id: I47d70a1e7bb754eedde7a19ab3980eadccfa23f0